### PR TITLE
feat: add autonomous agent loop setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/autonomous_task.yml
+++ b/.github/ISSUE_TEMPLATE/autonomous_task.yml
@@ -1,0 +1,55 @@
+name: Autonomous Task
+description: Task that agent loop should execute without human intervention
+title: "[Auto] "
+labels:
+  - type/task
+  - autonomous
+  - ready
+  - priority/p2
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What should be achieved?
+      placeholder: e.g. improve retry logic, add regression tests, reduce RPC failures
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: In Scope
+      description: What can the agent change?
+      placeholder: |
+        - file/path/a
+        - file/path/b
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope
+      description: What must not be changed?
+      placeholder: e.g. no schema changes, no new external service
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk Level
+      options:
+        - low
+        - medium
+        - high
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Completion criteria for autonomous merge
+      placeholder: |
+        - [ ] tests added or updated
+        - [ ] make test / make test-sidecar / make lint pass
+        - [ ] docs updated when behavior changed
+    validations:
+      required: true
+

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -55,4 +55,18 @@
 - name: ready-for-review
   color: 1D76DB
   description: Implementation complete and ready for review
-
+- name: autonomous
+  color: 0052CC
+  description: Eligible for autonomous agent execution
+- name: ready
+  color: 0E8A16
+  description: Ready to be picked from autonomous queue
+- name: in-progress
+  color: FBCA04
+  description: Currently being processed by agent loop
+- name: risk/high
+  color: B60205
+  description: High-risk change requiring explicit human confirmation
+- name: agent/needs-config
+  color: CFD3D7
+  description: Agent loop could not run because executor is not configured

--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -1,0 +1,53 @@
+name: Agent Loop
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run without mutating GitHub state"
+        required: false
+        default: "false"
+      max_issues:
+        description: "Max issues to process in one run"
+        required: false
+        default: "1"
+  schedule:
+    - cron: "*/15 * * * *"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: agent-loop-main
+  cancel-in-progress: false
+
+jobs:
+  loop:
+    name: Autonomous Queue Worker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git User
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Agent Loop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          BASE_BRANCH: main
+          AGENT_EXEC_CMD: ${{ vars.AGENT_EXEC_CMD }}
+          AUTONOMY_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          AGENT_MAX_ISSUES_PER_RUN: ${{ github.event.inputs.max_issues || '1' }}
+        run: scripts/agent_loop.sh
+

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ DDL 변경 없음. 기존 8개 테이블이 모든 체인을 수용합니다.
 - [Runbook](docs/runbook.md) — 장애 대응 및 복구 절차
 - [Definition Of Done](docs/definition-of-done.md) — 작업 완료 기준
 - [GitHub Collaboration](docs/github-collaboration.md) — 이슈/PR/라벨/승인 운영 규칙
+- [Autonomy Policy](docs/autonomy-policy.md) — 에이전트 자율 실행 정책 및 큐 규칙
 
 ## License
 

--- a/docs/autonomy-policy.md
+++ b/docs/autonomy-policy.md
@@ -1,0 +1,49 @@
+# Autonomy Policy
+
+## Goal
+- 사람 개입을 최소화하고, 필요할 때만 의사결정을 요청하는 자율 개발 루프를 운영한다.
+
+## Queue Contract
+- 에이전트가 집는 이슈 조건:
+  - `autonomous`
+  - `ready`
+- 에이전트가 자동으로 제외하는 이슈:
+  - `blocked`
+  - `decision-needed`
+  - `in-progress`
+  - `agent/needs-config`
+
+## Label State Machine
+1. 준비: `autonomous + ready`
+2. 실행 시작: `in-progress` (에이전트가 claim)
+3. 코드 제출: `ready-for-review` (Draft PR 링크 코멘트)
+4. 중단: `blocked` 또는 `decision-needed`
+
+## Human Escalation Rules
+아래 조건이면 자동 진행 중지 후 사람 판단 요청:
+1. 스키마 파괴적 변경 또는 데이터 손실 위험
+2. 인프라 비용/권한/보안 정책 변경
+3. 고위험 변경 (`risk/high`)
+4. 반복 실패(동일 이슈 3회 이상)
+
+## Required Repository Settings
+
+### 1) Actions Variable
+- 이름: `AGENT_EXEC_CMD`
+- 의미: 에이전트 구현/테스트 명령
+- 예시:
+  - `make test && make test-sidecar && make lint`
+  - `./scripts/your_agent_executor.sh`
+
+`AGENT_EXEC_CMD`가 비어 있으면 에이전트는 이슈를 `agent/needs-config`로 표시하고 중단한다.
+
+### 2) Scheduled Worker
+- 워크플로우: `.github/workflows/agent-loop.yml`
+- 주기: 15분
+- 수동 실행: `workflow_dispatch`
+
+## Operational Notes
+- 기본 실행자는 `ubuntu-latest`이다.
+- 진짜 상시 실행(긴 작업/대용량 작업)이 필요하면 self-hosted runner로 전환한다.
+- 브랜치 보호를 활성화해 직접 푸시를 금지하고 PR 경로만 허용한다.
+

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -2,6 +2,7 @@
 
 ## Core Principle
 - 구현은 비동기로 진행하되, 의사결정과 품질 상태는 GitHub에서 추적 가능해야 한다.
+- 사람 개입은 최소화하고, 필요한 경우에만 `decision-needed`로 에스컬레이션한다.
 
 ## Work Item Lifecycle
 1. Issue 생성:
@@ -13,7 +14,20 @@
 3. 브랜치 생성 후 Draft PR 오픈
 4. PR 본문에 변경 내용, 검증 결과, 리스크, 롤백 전략 누적
 5. CI 통과 후 `ready-for-review` 라벨 부여
-6. CODEOWNER 승인 후 merge
+6. 보호 규칙 충족 후 merge (팀 운영 시 CODEOWNER 승인 권장)
+
+## Autonomous Loop
+- 워크플로우: `.github/workflows/agent-loop.yml`
+- 큐 입력 라벨: `autonomous + ready`
+- 실행 중 라벨: `in-progress`
+- 결과 라벨: `ready-for-review` 또는 `blocked`
+- 실행 명령은 repository variable `AGENT_EXEC_CMD`로 주입한다.
+
+권장 실행 순서:
+1. `Autonomous Task` 이슈 생성
+2. `autonomous`, `ready`, `priority/*`, `area/*` 라벨 설정
+3. 에이전트 루프가 브랜치/PR 생성 후 테스트
+4. CI 통과 확인 후 merge
 
 ## Decision Protocol
 - 선택지가 필요한 경우 `Decision Needed` 이슈를 사용한다.

--- a/scripts/agent_loop.sh
+++ b/scripts/agent_loop.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd gh
+require_cmd jq
+require_cmd git
+
+REPO="${GITHUB_REPOSITORY:-}"
+if [ -z "${REPO}" ]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
+
+BASE_BRANCH="${BASE_BRANCH:-main}"
+WORK_BRANCH_PREFIX="${WORK_BRANCH_PREFIX:-agent-issue}"
+DECISION_REMINDER_HOURS="${DECISION_REMINDER_HOURS:-24}"
+AGENT_MAX_ISSUES_PER_RUN="${AGENT_MAX_ISSUES_PER_RUN:-1}"
+AUTONOMY_DRY_RUN="${AUTONOMY_DRY_RUN:-false}"
+AGENT_EXEC_CMD="${AGENT_EXEC_CMD:-}"
+
+log() {
+  printf '[agent-loop] %s\n' "$*"
+}
+
+should_dry_run() {
+  [ "${AUTONOMY_DRY_RUN}" = "true" ]
+}
+
+issue_has_label() {
+  local issue_json="$1"
+  local label_name="$2"
+  jq -e --arg name "${label_name}" '.labels[].name | select(. == $name)' >/dev/null <<<"${issue_json}"
+}
+
+pick_next_issue() {
+  gh issue list \
+    --repo "${REPO}" \
+    --state open \
+    --label autonomous \
+    --label ready \
+    --limit 200 \
+    --json number,title,body,url,createdAt,labels | jq -c '
+      def labels: [.labels[].name];
+      def prio:
+        if labels | index("priority/p0") then 0
+        elif labels | index("priority/p1") then 1
+        elif labels | index("priority/p2") then 2
+        elif labels | index("priority/p3") then 3
+        else 9 end;
+      map(select(
+        (labels | index("blocked") | not) and
+        (labels | index("decision-needed") | not) and
+        (labels | index("in-progress") | not) and
+        (labels | index("agent/needs-config") | not)
+      ))
+      | sort_by(prio, .createdAt)
+      | .[0]
+    '
+}
+
+comment_decision_reminders() {
+  local issues now_epoch age_limit issue_number issue_title issue_updated issue_url issue_epoch age_hours
+
+  issues="$(gh issue list \
+    --repo "${REPO}" \
+    --state open \
+    --label decision-needed \
+    --limit 200 \
+    --json number,title,updatedAt,url)"
+
+  now_epoch="$(date +%s)"
+  age_limit="$((DECISION_REMINDER_HOURS * 3600))"
+
+  while IFS= read -r line; do
+    [ -z "${line}" ] && continue
+
+    issue_number="$(jq -r '.number' <<<"${line}")"
+    issue_title="$(jq -r '.title' <<<"${line}")"
+    issue_updated="$(jq -r '.updatedAt' <<<"${line}")"
+    issue_url="$(jq -r '.url' <<<"${line}")"
+    issue_epoch="$(date -d "${issue_updated}" +%s)"
+    age_hours="$(((now_epoch - issue_epoch) / 3600))"
+
+    if [ $((now_epoch - issue_epoch)) -lt "${age_limit}" ]; then
+      continue
+    fi
+
+    log "decision-needed reminder on #${issue_number} (${age_hours}h stale)"
+    if should_dry_run; then
+      continue
+    fi
+
+    gh issue comment "${issue_number}" \
+      --repo "${REPO}" \
+      --body "[agent-reminder] This decision has been waiting for ${age_hours}h: ${issue_url}
+
+Please choose an option so autonomous execution can continue."
+  done < <(jq -c '.[]' <<<"${issues}")
+}
+
+claim_issue() {
+  local issue_number="$1"
+  local issue_url="$2"
+  local run_url="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_RUN_ID:-manual}"
+
+  log "claiming #${issue_number}"
+  if should_dry_run; then
+    return 0
+  fi
+
+  gh issue edit "${issue_number}" \
+    --repo "${REPO}" \
+    --add-label in-progress \
+    --remove-label ready \
+    --remove-label blocked \
+    --remove-label agent/needs-config >/dev/null
+
+  gh issue comment "${issue_number}" \
+    --repo "${REPO}" \
+    --body "[agent-loop] Claimed for autonomous execution.
+
+- issue: ${issue_url}
+- run: ${run_url}"
+}
+
+create_branch_for_issue() {
+  local issue_number="$1"
+  local issue_title="$2"
+  local slug branch
+
+  slug="$(tr '[:upper:]' '[:lower:]' <<<"${issue_title}" \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' \
+    | cut -c1-40)"
+  [ -z "${slug}" ] && slug="work"
+  branch="${WORK_BRANCH_PREFIX}-${issue_number}-${slug}"
+
+  log "preparing branch ${branch}"
+  if should_dry_run; then
+    echo "${branch}"
+    return 0
+  fi
+
+  git fetch origin "${BASE_BRANCH}"
+  git checkout -B "${branch}" "origin/${BASE_BRANCH}"
+  echo "${branch}"
+}
+
+handle_missing_executor() {
+  local issue_number="$1"
+  log "AGENT_EXEC_CMD is empty; cannot execute coding step for #${issue_number}"
+  if should_dry_run; then
+    return 0
+  fi
+
+  gh issue edit "${issue_number}" \
+    --repo "${REPO}" \
+    --remove-label in-progress \
+    --add-label agent/needs-config >/dev/null
+
+  gh issue comment "${issue_number}" \
+    --repo "${REPO}" \
+    --body "[agent-loop] Executor command is not configured.
+
+Set repository variable \`AGENT_EXEC_CMD\` to the command that performs implementation/testing, then move this issue back to \`ready\`."
+}
+
+run_executor() {
+  local issue_number="$1"
+  local issue_title="$2"
+  local issue_body="$3"
+  local issue_url="$4"
+
+  if [ -z "${AGENT_EXEC_CMD}" ]; then
+    handle_missing_executor "${issue_number}"
+    return 1
+  fi
+
+  export AGENT_ISSUE_NUMBER="${issue_number}"
+  export AGENT_ISSUE_TITLE="${issue_title}"
+  export AGENT_ISSUE_URL="${issue_url}"
+
+  mkdir -p .agent
+  printf '%s\n' "${issue_body}" > ".agent/issue-${issue_number}.md"
+  export AGENT_ISSUE_BODY_FILE=".agent/issue-${issue_number}.md"
+
+  log "running executor command for #${issue_number}"
+  if should_dry_run; then
+    return 0
+  fi
+
+  bash -lc "${AGENT_EXEC_CMD}"
+}
+
+open_or_update_pr() {
+  local issue_number="$1"
+  local issue_title="$2"
+  local branch="$3"
+  local pr_number pr_url
+
+  pr_number="$(gh pr list \
+    --repo "${REPO}" \
+    --head "${branch}" \
+    --state open \
+    --json number \
+    --jq '.[0].number // empty')"
+
+  if [ -n "${pr_number}" ]; then
+    pr_url="$(gh pr view "${pr_number}" --repo "${REPO}" --json url --jq .url)"
+    echo "${pr_url}"
+    return 0
+  fi
+
+  pr_url="$(gh pr create \
+    --repo "${REPO}" \
+    --draft \
+    --base "${BASE_BRANCH}" \
+    --head "${branch}" \
+    --title "chore(agent): ${issue_title} (#${issue_number})" \
+    --body "## Summary
+- Autonomous work for #${issue_number}
+
+## Notes
+- Generated by scheduled agent loop
+- Review risk and rollout plan before merge
+
+Closes #${issue_number}" | tail -n1)"
+
+  echo "${pr_url}"
+}
+
+finalize_issue_with_pr() {
+  local issue_number="$1"
+  local pr_url="$2"
+  if should_dry_run; then
+    return 0
+  fi
+
+  gh issue edit "${issue_number}" \
+    --repo "${REPO}" \
+    --remove-label in-progress \
+    --add-label ready-for-review >/dev/null
+
+  gh issue comment "${issue_number}" \
+    --repo "${REPO}" \
+    --body "[agent-loop] Draft PR created: ${pr_url}"
+}
+
+handle_no_changes() {
+  local issue_number="$1"
+  if should_dry_run; then
+    return 0
+  fi
+
+  gh issue edit "${issue_number}" \
+    --repo "${REPO}" \
+    --remove-label in-progress \
+    --add-label blocked >/dev/null
+
+  gh issue comment "${issue_number}" \
+    --repo "${REPO}" \
+    --body "[agent-loop] No file changes were produced by executor. Marked as \`blocked\` for manual follow-up."
+}
+
+process_issue() {
+  local issue_json="$1"
+  local issue_number issue_title issue_body issue_url branch pr_url commit_message
+
+  issue_number="$(jq -r '.number' <<<"${issue_json}")"
+  issue_title="$(jq -r '.title' <<<"${issue_json}")"
+  issue_body="$(jq -r '.body // ""' <<<"${issue_json}")"
+  issue_url="$(jq -r '.url' <<<"${issue_json}")"
+
+  claim_issue "${issue_number}" "${issue_url}"
+  branch="$(create_branch_for_issue "${issue_number}" "${issue_title}")"
+
+  if ! run_executor "${issue_number}" "${issue_title}" "${issue_body}" "${issue_url}"; then
+    return 0
+  fi
+
+  if [ -z "$(git status --porcelain)" ]; then
+    log "no changes after executor for #${issue_number}"
+    handle_no_changes "${issue_number}"
+    return 0
+  fi
+
+  if should_dry_run; then
+    log "dry-run mode: skipping commit/push/pr for #${issue_number}"
+    return 0
+  fi
+
+  git add -A
+  commit_message="chore(agent): implement #${issue_number} ${issue_title}"
+  git commit -m "${commit_message}" >/dev/null
+  git push -u origin "${branch}" >/dev/null
+
+  pr_url="$(open_or_update_pr "${issue_number}" "${issue_title}" "${branch}")"
+  finalize_issue_with_pr "${issue_number}" "${pr_url}"
+  log "issue #${issue_number} -> ${pr_url}"
+}
+
+main() {
+  local issue_json processed=0
+
+  log "repo=${REPO} base=${BASE_BRANCH} max=${AGENT_MAX_ISSUES_PER_RUN} dry_run=${AUTONOMY_DRY_RUN}"
+  comment_decision_reminders
+
+  while [ "${processed}" -lt "${AGENT_MAX_ISSUES_PER_RUN}" ]; do
+    issue_json="$(pick_next_issue)"
+
+    if [ -z "${issue_json}" ] || [ "${issue_json}" = "null" ]; then
+      log "no eligible autonomous issues in queue"
+      break
+    fi
+
+    process_issue "${issue_json}"
+    processed=$((processed + 1))
+  done
+}
+
+main "$@"
+


### PR DESCRIPTION
## Summary
- add scheduled autonomous queue worker workflow (`.github/workflows/agent-loop.yml`)
- add queue executor script (`scripts/agent_loop.sh`)
- add `Autonomous Task` issue template
- add autonomy policy documentation and collaboration guide updates
- extend labels for autonomous state machine

## Validation
- `bash -n scripts/agent_loop.sh`
- dry-run smoke test of agent loop against repository

## Notes
- set repository variable `AGENT_EXEC_CMD` to enable actual coding execution
