### PR TITLE
chore: support configurable runner for agent loop

### DIFF
--- a/.github/ISSUE_TEMPLATE/autonomous_task.yml
+++ b/.github/ISSUE_TEMPLATE/autonomous_task.yml
@@ -35,6 +35,7 @@ body:
     id: risk
     attributes:
       label: Risk Level
+      description: high를 선택하면 자동으로 `risk/high` 라벨이 붙고 사람 확인 전 실행이 중지됩니다.
       options:
         - low
         - medium
@@ -52,4 +53,3 @@ body:
         - [ ] docs updated when behavior changed
     validations:
       required: true
-

--- a/.github/ISSUE_TEMPLATE/decision-needed.yml
+++ b/.github/ISSUE_TEMPLATE/decision-needed.yml
@@ -3,6 +3,7 @@ description: Request explicit owner decision with options and deadline
 title: "[Decision] "
 labels:
   - decision-needed
+  - needs-opinion
 body:
   - type: textarea
     id: context
@@ -43,4 +44,3 @@ body:
       options:
         - label: If there is no response by the deadline, proceed with Option A.
           required: true
-

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -49,6 +49,9 @@
 - name: decision-needed
   color: 5319E7
   description: Owner decision is needed to proceed
+- name: needs-opinion
+  color: 8A2BE2
+  description: Explicit owner opinion is required before continuing
 - name: blocked
   color: 000000
   description: Work cannot proceed due to external dependency

--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -10,7 +10,7 @@ on:
       max_issues:
         description: "Max issues to process in one run"
         required: false
-        default: "1"
+        default: "2"
   schedule:
     - cron: "*/15 * * * *"
 
@@ -54,5 +54,7 @@ jobs:
           BASE_BRANCH: main
           AGENT_EXEC_CMD: ${{ vars.AGENT_EXEC_CMD }}
           AUTONOMY_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
-          AGENT_MAX_ISSUES_PER_RUN: ${{ github.event.inputs.max_issues || '1' }}
+          AGENT_MAX_ISSUES_PER_RUN: ${{ github.event.inputs.max_issues || vars.AGENT_MAX_ISSUES_PER_RUN || '2' }}
+          AGENT_MAX_AUTO_RETRIES: ${{ vars.AGENT_MAX_AUTO_RETRIES || '2' }}
+          DECISION_REMINDER_HOURS: ${{ vars.DECISION_REMINDER_HOURS || '24' }}
         run: scripts/agent_loop.sh

--- a/.github/workflows/autonomous-risk-labeler.yml
+++ b/.github/workflows/autonomous-risk-labeler.yml
@@ -1,0 +1,36 @@
+name: Autonomous Risk Labeler
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync-risk-label:
+    if: contains(github.event.issue.labels.*.name, 'autonomous')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync risk/high from issue form
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = (issue.body || "").toLowerCase();
+            const hasHighRisk = /#+\s*risk level[\s\S]{0,160}\bhigh\b/.test(body);
+            const labels = issue.labels.map((label) => label.name);
+            const hasRiskLabel = labels.includes("risk/high");
+
+            if (hasHighRisk && !hasRiskLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ["risk/high"],
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -418,6 +418,17 @@ type ChainAdapter interface {
 
 DDL 변경 없음. 기존 8개 테이블이 모든 체인을 수용합니다.
 
+## 24/7 Autonomous Agent Setup
+
+GitHub 이슈를 큐로 사용해 밤새 자동 작업하려면 아래 순서로 설정합니다.
+
+1. 브랜치 보호 적용:
+   - `scripts/setup_branch_protection.sh emperorhan/multichain-indexer main`
+2. 에이전트 변수 설정:
+   - `AGENT_EXEC_CMD='make test && make test-sidecar && make lint' AGENT_RUNNER='self-hosted' scripts/setup_agent_loop.sh emperorhan/multichain-indexer`
+3. 이슈는 `Autonomous Task` 템플릿으로 생성하고 `autonomous + ready` 라벨을 유지
+4. 의사결정이 필요하면 에이전트가 `decision-needed + needs-opinion` 라벨과 코멘트로 중단
+
 ## Docs
 
 - [Architecture](docs/architecture.md) — 상세 아키텍처 명세서

--- a/docs/autonomy-policy.md
+++ b/docs/autonomy-policy.md
@@ -10,6 +10,7 @@
 - 에이전트가 자동으로 제외하는 이슈:
   - `blocked`
   - `decision-needed`
+  - `needs-opinion`
   - `in-progress`
   - `agent/needs-config`
 
@@ -17,14 +18,19 @@
 1. 준비: `autonomous + ready`
 2. 실행 시작: `in-progress` (에이전트가 claim)
 3. 코드 제출: `ready-for-review` (Draft PR 링크 코멘트)
-4. 중단: `blocked` 또는 `decision-needed`
+4. 중단/승인대기: `blocked + decision-needed + needs-opinion`
+
+## Retry and Escalation
+- 실행기(`AGENT_EXEC_CMD`) 실패 시 자동 재시도한다.
+- 재시도 한도(`AGENT_MAX_AUTO_RETRIES`)를 초과하면 자동 실행을 멈추고 `decision-needed + needs-opinion`으로 전환한다.
+- 이슈에 `risk/high`가 붙으면 코드 변경 전에 즉시 사람 의사결정을 요청한다.
 
 ## Human Escalation Rules
 아래 조건이면 자동 진행 중지 후 사람 판단 요청:
 1. 스키마 파괴적 변경 또는 데이터 손실 위험
 2. 인프라 비용/권한/보안 정책 변경
 3. 고위험 변경 (`risk/high`)
-4. 반복 실패(동일 이슈 3회 이상)
+4. 반복 실패(동일 이슈에서 `AGENT_MAX_AUTO_RETRIES` 초과)
 
 ## Required Repository Settings
 
@@ -36,6 +42,11 @@
   - `./scripts/your_agent_executor.sh`
 
 `AGENT_EXEC_CMD`가 비어 있으면 에이전트는 이슈를 `agent/needs-config`로 표시하고 중단한다.
+
+### 1-1) Optional Throughput/Safety Variables
+- `AGENT_MAX_ISSUES_PER_RUN` (기본 `2`): 한 번의 루프에서 처리할 최대 이슈 수
+- `AGENT_MAX_AUTO_RETRIES` (기본 `2`): 동일 이슈 자동 재시도 횟수
+- `DECISION_REMINDER_HOURS` (기본 `24`): `decision-needed` 리마인드 코멘트 간격(시간)
 
 ### 2) Runner 선택 (권장)
 - 이름: `AGENT_RUNNER`

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -2,7 +2,7 @@
 
 ## Core Principle
 - 구현은 비동기로 진행하되, 의사결정과 품질 상태는 GitHub에서 추적 가능해야 한다.
-- 사람 개입은 최소화하고, 필요한 경우에만 `decision-needed`로 에스컬레이션한다.
+- 사람 개입은 최소화하고, 필요한 경우에만 `decision-needed + needs-opinion`으로 에스컬레이션한다.
 
 ## Work Item Lifecycle
 1. Issue 생성:
@@ -20,9 +20,11 @@
 - 워크플로우: `.github/workflows/agent-loop.yml`
 - 큐 입력 라벨: `autonomous + ready`
 - 실행 중 라벨: `in-progress`
-- 결과 라벨: `ready-for-review` 또는 `blocked`
+- 결과 라벨: `ready-for-review` 또는 `blocked + decision-needed + needs-opinion`
 - 실행 명령은 repository variable `AGENT_EXEC_CMD`로 주입한다.
 - runner는 `AGENT_RUNNER` variable로 지정한다 (비어 있으면 `ubuntu-latest`).
+- `risk/high` 라벨 이슈는 사람 확인 전 자동 실행하지 않는다.
+- `AGENT_MAX_AUTO_RETRIES`를 넘겨 실패하면 사람 확인 상태로 자동 전환한다.
 
 권장 실행 순서:
 1. `Autonomous Task` 이슈 생성
@@ -34,13 +36,14 @@
 - 선택지가 필요한 경우 `Decision Needed` 이슈를 사용한다.
 - Option A를 기본안으로 제시한다.
 - 마감 시간까지 응답이 없으면 기본안으로 진행한다.
+- 실행기는 결정 필요 시 원본 이슈 코멘트에서 1/2/3 옵션으로 응답을 요청한다.
 
 ## Label Taxonomy
 - `type/task`, `type/bug`, `type/docs`, `type/chore`
 - `area/pipeline`, `area/sidecar`, `area/storage`, `area/infra`
 - `priority/p0` ~ `priority/p3`
 - `sev0` ~ `sev3`
-- `decision-needed`, `blocked`, `ready-for-review`
+- `decision-needed`, `needs-opinion`, `blocked`, `ready-for-review`
 
 ## Required Status Checks
 - `Go Test + Build`

--- a/scripts/setup_agent_loop.sh
+++ b/scripts/setup_agent_loop.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   AGENT_EXEC_CMD='your executor command' \
+#   AGENT_RUNNER='self-hosted' \
+#   AGENT_MAX_ISSUES_PER_RUN='2' \
+#   AGENT_MAX_AUTO_RETRIES='2' \
+#   DECISION_REMINDER_HOURS='24' \
+#   scripts/setup_agent_loop.sh [owner/repo]
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required. Install from https://cli.github.com/" >&2
+  exit 1
+fi
+
+REPO="${1:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+AGENT_EXEC_CMD_VALUE="${AGENT_EXEC_CMD:-}"
+AGENT_RUNNER_VALUE="${AGENT_RUNNER:-}"
+AGENT_MAX_ISSUES_PER_RUN_VALUE="${AGENT_MAX_ISSUES_PER_RUN:-2}"
+AGENT_MAX_AUTO_RETRIES_VALUE="${AGENT_MAX_AUTO_RETRIES:-2}"
+DECISION_REMINDER_HOURS_VALUE="${DECISION_REMINDER_HOURS:-24}"
+
+if [ -z "${AGENT_EXEC_CMD_VALUE}" ]; then
+  echo "AGENT_EXEC_CMD is required." >&2
+  echo "Example: AGENT_EXEC_CMD='make test && make lint' scripts/setup_agent_loop.sh ${REPO}" >&2
+  exit 1
+fi
+
+set_repo_var() {
+  local name="$1"
+  local value="$2"
+  gh variable set "${name}" --repo "${REPO}" --body "${value}" >/dev/null
+  echo "set ${name}"
+}
+
+echo "Configuring agent loop variables on ${REPO}"
+set_repo_var "AGENT_EXEC_CMD" "${AGENT_EXEC_CMD_VALUE}"
+set_repo_var "AGENT_MAX_ISSUES_PER_RUN" "${AGENT_MAX_ISSUES_PER_RUN_VALUE}"
+set_repo_var "AGENT_MAX_AUTO_RETRIES" "${AGENT_MAX_AUTO_RETRIES_VALUE}"
+set_repo_var "DECISION_REMINDER_HOURS" "${DECISION_REMINDER_HOURS_VALUE}"
+
+if [ -n "${AGENT_RUNNER_VALUE}" ]; then
+  set_repo_var "AGENT_RUNNER" "${AGENT_RUNNER_VALUE}"
+fi
+
+echo "Done."
+echo "Next:"
+echo "1) Ensure .github/workflows/agent-loop.yml is enabled"
+echo "2) Create Autonomous Task issues with labels: autonomous + ready"
+echo "3) Protect main branch (scripts/setup_branch_protection.sh ${REPO} main)"


### PR DESCRIPTION
## Summary
- allow `agent-loop` workflow runner to be configured via `AGENT_RUNNER` variable
- add tooling preflight step (`gh`, `jq`, `git`)
- document `AGENT_RUNNER` in autonomy and collaboration docs

## Validation
- workflow YAML reviewed
- script/docs consistency checked
