### PR TITLE
feat: add codex executor script for autonomous agent loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ GitHub 이슈를 큐로 사용해 밤새 자동 작업하려면 아래 순서로
 1. 브랜치 보호 적용:
    - `scripts/setup_branch_protection.sh emperorhan/multichain-indexer main`
 2. 에이전트 변수 설정:
-   - `AGENT_EXEC_CMD='make test && make test-sidecar && make lint' AGENT_RUNNER='self-hosted' scripts/setup_agent_loop.sh emperorhan/multichain-indexer`
+   - `AGENT_EXEC_CMD='scripts/agent_executor.sh' AGENT_RUNNER='self-hosted' scripts/setup_agent_loop.sh emperorhan/multichain-indexer`
 3. 이슈는 `Autonomous Task` 템플릿으로 생성하고 `autonomous + ready` 라벨을 유지
 4. 의사결정이 필요하면 에이전트가 `decision-needed + needs-opinion` 라벨과 코멘트로 중단
 

--- a/scripts/agent_executor.sh
+++ b/scripts/agent_executor.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "codex CLI is required on the runner." >&2
+  exit 2
+fi
+
+ISSUE_NUMBER="${AGENT_ISSUE_NUMBER:-}"
+ISSUE_TITLE="${AGENT_ISSUE_TITLE:-}"
+ISSUE_URL="${AGENT_ISSUE_URL:-}"
+ISSUE_BODY_FILE="${AGENT_ISSUE_BODY_FILE:-}"
+
+if [ -z "${ISSUE_NUMBER}" ] || [ -z "${ISSUE_BODY_FILE}" ] || [ ! -f "${ISSUE_BODY_FILE}" ]; then
+  echo "agent issue context is missing. expected AGENT_ISSUE_NUMBER and AGENT_ISSUE_BODY_FILE." >&2
+  exit 3
+fi
+
+PROMPT="$(cat <<EOF
+You are the autonomous implementation executor for this repository.
+
+GitHub issue:
+- number: #${ISSUE_NUMBER}
+- title: ${ISSUE_TITLE}
+- url: ${ISSUE_URL}
+- body file: ${ISSUE_BODY_FILE}
+
+Instructions:
+1. Read the issue body file and extract objective, in-scope, out-of-scope, risk, acceptance criteria.
+2. Implement only in-scope changes.
+3. Do not bypass risky or ambiguous decisions; if blocked by missing owner decision, exit non-zero.
+4. Update docs/tests when behavior changes.
+5. Run validation commands and leave the workspace in a committable state:
+   - make test
+   - make test-sidecar
+   - make lint
+EOF
+)"
+
+codex exec --full-auto --cd "$(pwd)" "${PROMPT}"


### PR DESCRIPTION
## Summary
- add scripts/agent_executor.sh so agent-loop can execute Codex non-interactively
- update README setup example to AGENT_EXEC_CMD='scripts/agent_executor.sh'

## Validation
- bash -n scripts/agent_executor.sh