### PR TITLE
feat: automatic x.y.z versioning and release notes

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -103,3 +103,12 @@
 - name: qa/failed
   color: D73A4A
   description: QA validation failed
+- name: release/major
+  color: B60205
+  description: Next release should bump MAJOR
+- name: release/minor
+  color: FBCA04
+  description: Next release should bump MINOR
+- name: release/patch
+  color: 0E8A16
+  description: Next release should bump PATCH

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - release/major
+        - decision/major
+    - title: Features
+      labels:
+        - release/minor
+        - type/task
+    - title: Fixes
+      labels:
+        - release/patch
+        - type/bug
+    - title: Maintenance
+      labels:
+        - type/chore
+        - type/docs
+  exclude:
+    labels:
+      - skip-changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,169 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump strategy"
+        required: false
+        type: choice
+        default: auto
+        options:
+          - auto
+          - major
+          - minor
+          - patch
+      dry_run:
+        description: "Compute only, do not tag/release"
+        required: false
+        default: "false"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect Bump From PR Labels
+        id: detect
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.sha;
+            let bump = "patch";
+            let source = "default";
+            let prNumber = "";
+
+            try {
+              const pulls = await github.request("GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls", {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              });
+
+              if (pulls.data.length > 0) {
+                const pr = pulls.data[0];
+                prNumber = String(pr.number);
+                const labels = (pr.labels || []).map((l) => l.name);
+
+                if (labels.includes("release/major") || labels.includes("decision/major")) {
+                  bump = "major";
+                  source = "pr-label";
+                } else if (labels.includes("release/minor") || labels.includes("type/task")) {
+                  bump = "minor";
+                  source = "pr-label";
+                } else if (labels.includes("release/patch") || labels.includes("type/bug") || labels.includes("type/chore") || labels.includes("type/docs")) {
+                  bump = "patch";
+                  source = "pr-label";
+                }
+              }
+            } catch (err) {
+              core.warning(`Could not resolve PR labels for ${sha}: ${err.message}`);
+            }
+
+            core.setOutput("bump", bump);
+            core.setOutput("source", source);
+            core.setOutput("pr_number", prNumber);
+
+      - name: Resolve Bump Strategy
+        id: resolve
+        run: |
+          INPUT_BUMP="${{ github.event.inputs.bump || 'auto' }}"
+          DETECTED="${{ steps.detect.outputs.bump }}"
+
+          if [ "${INPUT_BUMP}" = "auto" ]; then
+            BUMP="${DETECTED}"
+          else
+            BUMP="${INPUT_BUMP}"
+          fi
+
+          echo "bump=${BUMP}" >> "${GITHUB_OUTPUT}"
+
+      - name: Compute Next Version
+        id: version
+        run: |
+          set -euo pipefail
+
+          latest_tag="$(git tag -l 'v*.*.*' --sort=-v:refname | head -n1)"
+          if [ -z "${latest_tag}" ]; then
+            latest_tag="v0.0.0"
+          fi
+
+          version="${latest_tag#v}"
+          IFS='.' read -r major minor patch <<< "${version}"
+
+          bump="${{ steps.resolve.outputs.bump }}"
+          case "${bump}" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch)
+              patch=$((patch + 1))
+              ;;
+            *)
+              echo "Unsupported bump: ${bump}" >&2
+              exit 1
+              ;;
+          esac
+
+          next_tag="v${major}.${minor}.${patch}"
+          if git rev-parse "${next_tag}" >/dev/null 2>&1; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+          echo "previous_tag=${latest_tag}" >> "${GITHUB_OUTPUT}"
+          echo "next_tag=${next_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Configure Git User
+        if: steps.version.outputs.exists == 'false' && (github.event.inputs.dry_run || 'false') != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create Git Tag
+        if: steps.version.outputs.exists == 'false' && (github.event.inputs.dry_run || 'false') != 'true'
+        run: |
+          tag="${{ steps.version.outputs.next_tag }}"
+          git tag -a "${tag}" -m "release: ${tag}"
+          git push origin "${tag}"
+
+      - name: Publish GitHub Release
+        if: steps.version.outputs.exists == 'false' && (github.event.inputs.dry_run || 'false') != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.next_tag }}" \
+            --repo "${{ github.repository }}" \
+            --title "${{ steps.version.outputs.next_tag }}" \
+            --generate-notes
+
+      - name: Release Summary
+        run: |
+          echo "bump=${{ steps.resolve.outputs.bump }}"
+          echo "source=${{ steps.detect.outputs.source }}"
+          echo "pr=${{ steps.detect.outputs.pr_number }}"
+          echo "previous=${{ steps.version.outputs.previous_tag }}"
+          echo "next=${{ steps.version.outputs.next_tag }}"
+          echo "exists=${{ steps.version.outputs.exists }}"

--- a/README.md
+++ b/README.md
@@ -447,6 +447,9 @@ GitHub 이슈를 큐로 사용해 밤새 자동 작업하려면 아래 순서로
 11. 로컬 반복 루프(Playbook 스타일):
    - 작업 지시를 `.agent/ralph_task.md`에 작성
    - `MAX_LOOPS=6 scripts/ralph_loop_local.sh`
+12. 릴리즈 자동화:
+   - `main` 반영 시 `release.yml`이 `vX.Y.Z` 태그와 릴리즈 노트 자동 생성
+   - PR 라벨 `release/major|minor|patch`로 버전 범위를 제어
 
 ## Docs
 

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -81,6 +81,15 @@
 - `Go Lint`
 - `Sidecar Test + Build`
 
+## Release Automation
+- 워크플로우: `.github/workflows/release.yml`
+- 트리거: `main` push 또는 수동 실행
+- 버전 규칙: `vX.Y.Z` (SemVer)
+  - `release/major` 또는 `decision/major` -> major bump
+  - `release/minor` 또는 `type/task` -> minor bump
+  - 그 외(`release/patch`, `type/bug`, `type/chore`, `type/docs`) -> patch bump
+- 릴리즈 노트: GitHub 자동 생성 노트 + `.github/release.yml` 카테고리 적용
+
 ## Branch Protection (GitHub Settings)
 기본 브랜치(`main`)에 아래 규칙 적용:
 1. Require a pull request before merging


### PR DESCRIPTION
## Summary
- add semantic release workflow on main push and manual dispatch
- derive bump from PR labels (release/major|minor|patch) with sensible defaults
- create and push vX.Y.Z tags automatically
- publish GitHub release with auto-generated release notes
- add .github/release.yml changelog categories

## Version Policy
- major: release/major or decision/major
- minor: release/minor or type/task
- patch: release/patch, type/bug, type/chore, type/docs

## Validation
- workflow YAML reviewed
- git diff --check clean