### PR TITLE
fix(agent-loop): avoid invalid refspec from log pollution

### DIFF
--- a/scripts/agent_loop.sh
+++ b/scripts/agent_loop.sh
@@ -27,7 +27,7 @@ AGENT_EXEC_CMD="${AGENT_EXEC_CMD:-}"
 PLANNING_EXEC_CMD="${PLANNING_EXEC_CMD:-scripts/planning_executor.sh}"
 
 log() {
-  printf '[agent-loop] %s\n' "$*"
+  printf '[agent-loop] %s\n' "$*" >&2
 }
 
 should_dry_run() {


### PR DESCRIPTION
## Summary
- send agent-loop logs to stderr
- prevent branch variable corruption when using command substitution in create_branch_for_issue

## Validation
- bash -n scripts/agent_loop.sh

Fixes automation stability regression seen in recent Agent Loop runs.
