### PR TITLE
feat(ralph): mobile control + operator aliases + status board

### DIFF
--- a/.github/workflows/ralph-loop-control.yml
+++ b/.github/workflows/ralph-loop-control.yml
@@ -4,48 +4,63 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "Toggle mode"
+        description: "Control mode"
         required: true
         type: choice
         options:
           - "on"
           - "off"
+          - "status"
       note:
         description: "Optional operator note"
         required: false
         default: ""
+      kick_agent_loop:
+        description: "Run Agent Loop once after mode change"
+        required: false
+        type: choice
+        options:
+          - "no"
+          - "yes"
+        default: "no"
+      kick_max_issues:
+        description: "Max issues for one-time Agent Loop kick"
+        required: false
+        default: "1"
 
 permissions:
-  actions: write
   contents: read
 
 jobs:
   toggle:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AGENT_RUNNER != '' && vars.AGENT_RUNNER || 'self-hosted' }}
     steps:
-      - name: Toggle RALPH loop variable
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const mode = ${{ toJSON(github.event.inputs.mode) }};
-            const value = mode === 'on' ? 'true' : 'false';
-            const note = ${{ toJSON(github.event.inputs.note) }};
+      - name: Checkout
+        uses: actions/checkout@v4
 
-            const payload = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'RALPH_LOOP_ENABLED',
-              value,
-            };
+      - name: Control Ralph Loop
+        env:
+          GH_TOKEN: ${{ secrets.RALPH_ADMIN_TOKEN }}
+          MODE: ${{ github.event.inputs.mode }}
+          NOTE: ${{ github.event.inputs.note }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::RALPH_ADMIN_TOKEN is not set. Falling back to runner gh auth."
+          fi
+          scripts/toggle_ralph_loop.sh "${MODE}" "${REPO}"
+          if [ -n "${NOTE}" ]; then
+            echo "::notice::note=${NOTE}"
+          fi
 
-            try {
-              await github.rest.actions.updateRepoVariable(payload);
-            } catch (err) {
-              if (err.status !== 404) throw err;
-              await github.rest.actions.createRepoVariable(payload);
-            }
-
-            core.notice(`RALPH_LOOP_ENABLED=${value}`);
-            if (note) {
-              core.notice(`note=${note}`);
-            }
+      - name: Kick Agent Loop (optional)
+        if: ${{ github.event.inputs.kick_agent_loop == 'yes' && github.event.inputs.mode != 'off' }}
+        env:
+          GH_TOKEN: ${{ secrets.RALPH_ADMIN_TOKEN }}
+          REPO: ${{ github.repository }}
+          MAX_ISSUES: ${{ github.event.inputs.kick_max_issues }}
+        run: |
+          set -euo pipefail
+          gh workflow run "Agent Loop" --repo "${REPO}" -f dry_run=false -f max_issues="${MAX_ISSUES}"
+          echo "::notice::Agent Loop kick requested (max_issues=${MAX_ISSUES})"

--- a/.github/workflows/ralph-status-board.yml
+++ b/.github/workflows/ralph-status-board.yml
@@ -1,0 +1,58 @@
+name: Ralph Status Board
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "*/30 * * * *"
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: ralph-status-board
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ${{ vars.AGENT_RUNNER != '' && vars.AGENT_RUNNER || 'self-hosted' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate Snapshot
+        env:
+          GH_TOKEN: ${{ secrets.RALPH_ADMIN_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::RALPH_ADMIN_TOKEN is not set. Falling back to runner gh auth."
+          fi
+          scripts/ralph_status_snapshot.sh "${REPO}" > /tmp/ralph-status.md
+          cat /tmp/ralph-status.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upsert Board Issue
+        env:
+          GH_TOKEN: ${{ secrets.RALPH_ADMIN_TOKEN }}
+          REPO: ${{ github.repository }}
+          TITLE: "[Ops] Ralph Loop Status Board"
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::RALPH_ADMIN_TOKEN is not set. Falling back to runner gh auth."
+          fi
+          issue_number="$(gh issue list --repo "${REPO}" --state open --search "${TITLE} in:title" --json number,title --jq '.[] | select(.title == "'"${TITLE}"'") | .number' | head -n1 || true)"
+          if [ -z "${issue_number}" ]; then
+            gh issue create \
+              --repo "${REPO}" \
+              --title "${TITLE}" \
+              --label "type/chore" \
+              --label "area/infra" \
+              --body-file /tmp/ralph-status.md >/dev/null
+            echo "::notice::created status board issue"
+            exit 0
+          fi
+          gh issue edit "${issue_number}" --repo "${REPO}" --body-file /tmp/ralph-status.md >/dev/null
+          echo "::notice::updated status board issue #${issue_number}"

--- a/README.md
+++ b/README.md
@@ -440,7 +440,10 @@ GitHub 이슈를 큐로 사용해 밤새 자동 작업하려면 아래 순서로
    - QA 실패 triage: `gpt-5.3-codex`
 9. 전역 ON/OFF:
    - `RALPH_LOOP_ENABLED=true|false` 변수로 전체 자율 루프 토글
-   - 수동 토글: `.github/workflows/ralph-loop-control.yml` 또는 `scripts/toggle_ralph_loop.sh on|off`
+   - 수동 토글: `.github/workflows/ralph-loop-control.yml` 또는 `scripts/toggle_ralph_loop.sh on|off|status`
+   - 터미널 단축: `scripts/install_ralph_aliases.sh` 후 `ron|roff|rstat|rkick|rscout`
+   - 휴대폰 제어: GitHub App -> Actions -> `Ralph Loop Control` 실행 (on/off/status + optional kick)
+   - 휴대폰 상태 확인: Actions -> `Ralph Status Board` 또는 이슈 `[Ops] Ralph Loop Status Board`
 10. 주요 의사결정:
    - `Major Decision` 템플릿 사용 (`decision/major`)
    - 해당 이슈는 owner 입력 전 자동 실행이 진행되지 않음

--- a/docs/autonomy-policy.md
+++ b/docs/autonomy-policy.md
@@ -9,7 +9,10 @@
   - `false`: `agent-loop`, `issue-scout`, `manager-loop`, `qa-loop` 모두 정지
 - 운영 토글 수단:
   - workflow: `.github/workflows/ralph-loop-control.yml`
-  - CLI: `scripts/toggle_ralph_loop.sh on|off`
+  - CLI: `scripts/toggle_ralph_loop.sh on|off|status`
+  - short alias: `scripts/install_ralph_aliases.sh` 후 `ron|roff|rstat|rkick|rscout`
+  - mobile: GitHub App > Actions > `Ralph Loop Control` (on/off/status + optional kick)
+  - quick view: Actions > `Ralph Status Board` 또는 이슈 `[Ops] Ralph Loop Status Board`
 
 ## Queue Contract
 - 에이전트가 집는 이슈 조건:

--- a/scripts/install_ralph_aliases.sh
+++ b/scripts/install_ralph_aliases.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs short aliases into ~/.bashrc (or custom rc path).
+# Usage:
+#   scripts/install_ralph_aliases.sh [rc_file]
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RC_FILE="${1:-${HOME}/.bashrc}"
+BEGIN_MARK="# >>> ralph aliases >>>"
+END_MARK="# <<< ralph aliases <<<"
+
+mkdir -p "$(dirname "${RC_FILE}")"
+touch "${RC_FILE}"
+
+tmp_file="$(mktemp)"
+trap 'rm -f "${tmp_file}"' EXIT
+
+awk -v begin="${BEGIN_MARK}" -v end="${END_MARK}" '
+  $0 == begin { skip=1; next }
+  $0 == end { skip=0; next }
+  !skip { print }
+' "${RC_FILE}" > "${tmp_file}"
+
+cat >> "${tmp_file}" <<EOF
+${BEGIN_MARK}
+alias ralph='bash ${ROOT_DIR}/scripts/ralphctl.sh'
+alias ron='ralph on'
+alias roff='ralph off'
+alias rstat='ralph status'
+alias rkick='ralph kick'
+alias rscout='ralph scout'
+${END_MARK}
+EOF
+
+mv "${tmp_file}" "${RC_FILE}"
+echo "Installed Ralph aliases into ${RC_FILE}"
+echo "Run: source ${RC_FILE}"

--- a/scripts/ralph_status_snapshot.sh
+++ b/scripts/ralph_status_snapshot.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generates a concise markdown status snapshot for mobile checking.
+# Usage:
+#   scripts/ralph_status_snapshot.sh [owner/repo]
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required. Install from https://cli.github.com/" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required." >&2
+  exit 1
+fi
+
+REPO="${1:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+NOW_UTC="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+
+ralph_enabled="$(gh variable get RALPH_LOOP_ENABLED --repo "${REPO}" 2>/dev/null || true)"
+[ -z "${ralph_enabled}" ] && ralph_enabled="unset"
+
+runner_line="$(gh api "repos/${REPO}/actions/runners" \
+  --jq '.runners[]? | select((.labels | map(.name) | index("multichain-indexer")) != null) | "\(.name) | \(.status) | busy=\(.busy)"' \
+  | head -n1 || true)"
+[ -z "${runner_line}" ] && runner_line="(runner not found)"
+
+open_counts="$(gh issue list --repo "${REPO}" --state open --limit 200 --json labels \
+  | jq -r '
+      def has_label($x): ((.labels // []) | map(.name) | index($x)) != null;
+      {
+        autonomous_ready: ([.[] | select(has_label("autonomous") and has_label("ready"))] | length),
+        in_progress: ([.[] | select(has_label("in-progress"))] | length),
+        decision_needed: ([.[] | select(has_label("decision-needed"))] | length),
+        qa_ready: ([.[] | select(has_label("qa-ready"))] | length)
+      }')"
+
+autonomous_ready="$(jq -r '.autonomous_ready' <<<"${open_counts}")"
+in_progress="$(jq -r '.in_progress' <<<"${open_counts}")"
+decision_needed="$(jq -r '.decision_needed' <<<"${open_counts}")"
+qa_ready="$(jq -r '.qa_ready' <<<"${open_counts}")"
+
+recent_runs_json="$(gh run list --repo "${REPO}" --limit 30 --json databaseId,name,status,conclusion,createdAt)"
+last_run() {
+  local workflow_name="$1"
+  jq -r --arg name "${workflow_name}" '
+    (map(select(.name == $name)) | sort_by(.createdAt) | reverse | .[0]) as $r
+    | if $r == null then "no-runs"
+      else "#\($r.databaseId) \($r.status)/\($r.conclusion // "n/a") @ \($r.createdAt)"
+      end
+  ' <<<"${recent_runs_json}"
+}
+
+agent_run="$(last_run "Agent Loop")"
+scout_run="$(last_run "Issue Scout")"
+manager_run="$(last_run "Manager Loop")"
+qa_run="$(last_run "QA Loop")"
+release_run="$(last_run "Release")"
+
+latest_release="$(gh release list --repo "${REPO}" --limit 1 --json tagName,publishedAt,isLatest \
+  --jq 'if length == 0 then "none" else .[0].tagName + " @ " + .[0].publishedAt end')"
+
+cat <<EOF
+## Ralph Loop Status Board
+
+- updated: ${NOW_UTC}
+- repo: ${REPO}
+- ralph_loop_enabled: ${ralph_enabled}
+- runner: ${runner_line}
+- latest_release: ${latest_release}
+
+### Queue
+- autonomous_ready: ${autonomous_ready}
+- in_progress: ${in_progress}
+- decision_needed: ${decision_needed}
+- qa_ready: ${qa_ready}
+
+### Recent Workflow Runs
+- Agent Loop: ${agent_run}
+- Issue Scout: ${scout_run}
+- Manager Loop: ${manager_run}
+- QA Loop: ${qa_run}
+- Release: ${release_run}
+EOF

--- a/scripts/ralphctl.sh
+++ b/scripts/ralphctl.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Quick operator control wrapper.
+# Usage:
+#   scripts/ralphctl.sh on|off|status [owner/repo]
+#   scripts/ralphctl.sh kick [owner/repo] [max_issues]
+#   scripts/ralphctl.sh scout [owner/repo] [max_issues]
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required. Install from https://cli.github.com/" >&2
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CMD="${1:-}"
+REPO_DEFAULT="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ralphctl.sh on [owner/repo]
+  ralphctl.sh off [owner/repo]
+  ralphctl.sh status [owner/repo]
+  ralphctl.sh kick [owner/repo] [max_issues]
+  ralphctl.sh scout [owner/repo] [max_issues]
+EOF
+}
+
+case "${CMD}" in
+  on|off|status)
+    REPO="${2:-${REPO_DEFAULT}}"
+    "${ROOT_DIR}/scripts/toggle_ralph_loop.sh" "${CMD}" "${REPO}"
+    ;;
+  kick)
+    REPO="${2:-${REPO_DEFAULT}}"
+    MAX_ISSUES="${3:-1}"
+    gh workflow run "Agent Loop" --repo "${REPO}" -f dry_run=false -f max_issues="${MAX_ISSUES}"
+    echo "Triggered Agent Loop on ${REPO} (max_issues=${MAX_ISSUES})"
+    ;;
+  scout)
+    REPO="${2:-${REPO_DEFAULT}}"
+    MAX_ISSUES="${3:-1}"
+    gh workflow run "Issue Scout" --repo "${REPO}" -f dry_run=false -f max_issues="${MAX_ISSUES}"
+    echo "Triggered Issue Scout on ${REPO} (max_issues=${MAX_ISSUES})"
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/scripts/toggle_ralph_loop.sh
+++ b/scripts/toggle_ralph_loop.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Usage:
 #   scripts/toggle_ralph_loop.sh on [owner/repo]
 #   scripts/toggle_ralph_loop.sh off [owner/repo]
+#   scripts/toggle_ralph_loop.sh status [owner/repo]
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "gh CLI is required. Install from https://cli.github.com/" >&2
@@ -13,9 +14,18 @@ fi
 MODE="${1:-}"
 REPO="${2:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
 
-if [ "${MODE}" != "on" ] && [ "${MODE}" != "off" ]; then
-  echo "Usage: scripts/toggle_ralph_loop.sh <on|off> [owner/repo]" >&2
+if [ "${MODE}" != "on" ] && [ "${MODE}" != "off" ] && [ "${MODE}" != "status" ]; then
+  echo "Usage: scripts/toggle_ralph_loop.sh <on|off|status> [owner/repo]" >&2
   exit 1
+fi
+
+if [ "${MODE}" = "status" ]; then
+  value="$(gh variable get RALPH_LOOP_ENABLED --repo "${REPO}" 2>/dev/null || true)"
+  if [ -z "${value}" ]; then
+    value="unset"
+  fi
+  echo "RALPH_LOOP_ENABLED=${value} (${REPO})"
+  exit 0
 fi
 
 if [ "${MODE}" = "on" ]; then


### PR DESCRIPTION
## Summary
- replace Ralph Loop Control implementation with runner `gh`-based control (supports `on/off/status` + optional one-shot Agent Loop kick)
- add `ralphctl` and alias installer for easy local control: `ron/roff/rstat/rkick/rscout`
- add `Ralph Status Board` workflow + snapshot script to keep one mobile-friendly status issue updated
- extend docs for mobile-first 운영 경로

## Validation
- `bash -n scripts/toggle_ralph_loop.sh scripts/ralphctl.sh scripts/install_ralph_aliases.sh scripts/ralph_status_snapshot.sh`
- `scripts/ralphctl.sh status emperorhan/multichain-indexer`
- `scripts/ralph_status_snapshot.sh emperorhan/multichain-indexer`
- `/bin/bash -ic "rstat"`
