### PR TITLE
fix(agent): codex CLI approval flag compatibility

### DIFF
--- a/scripts/agent_executor.sh
+++ b/scripts/agent_executor.sh
@@ -64,10 +64,11 @@ EOF
 )"
 
 cmd=(
-  codex exec
+  codex
+  --ask-for-approval "${AGENT_CODEX_APPROVAL}"
+  exec
   --model "${SELECTED_MODEL}"
   --sandbox "${AGENT_CODEX_SANDBOX}"
-  --ask-for-approval "${AGENT_CODEX_APPROVAL}"
   --cd "$(pwd)"
 )
 

--- a/scripts/planning_executor.sh
+++ b/scripts/planning_executor.sh
@@ -41,10 +41,11 @@ EOF
 )"
 
 cmd=(
-  codex exec
+  codex
+  --ask-for-approval "${PLANNING_CODEX_APPROVAL}"
+  exec
   --model "${PLANNING_CODEX_MODEL}"
   --sandbox "${PLANNING_CODEX_SANDBOX}"
-  --ask-for-approval "${PLANNING_CODEX_APPROVAL}"
   --cd "$(pwd)"
 )
 

--- a/scripts/qa_triage_executor.sh
+++ b/scripts/qa_triage_executor.sh
@@ -47,10 +47,11 @@ EOF
 )"
 
 cmd=(
-  codex exec
+  codex
+  --ask-for-approval "${QA_TRIAGE_CODEX_APPROVAL}"
+  exec
   --model "${QA_TRIAGE_CODEX_MODEL}"
   --sandbox "${QA_TRIAGE_CODEX_SANDBOX}"
-  --ask-for-approval "${QA_TRIAGE_CODEX_APPROVAL}"
   --cd "$(pwd)"
 )
 

--- a/scripts/ralph_loop_local.sh
+++ b/scripts/ralph_loop_local.sh
@@ -62,10 +62,11 @@ EOF
 )"
 
   cmd=(
-    codex exec
+    codex
+    --ask-for-approval "${CODEX_APPROVAL}"
+    exec
     --model "${CODEX_MODEL_FAST}"
     --sandbox "${CODEX_SANDBOX}"
-    --ask-for-approval "${CODEX_APPROVAL}"
     --cd "$(pwd)"
   )
 


### PR DESCRIPTION
## Summary
- fix autonomous executors to pass `--ask-for-approval` in the correct global option position for current Codex CLI
- apply same compatibility fix to:
  - `scripts/agent_executor.sh`
  - `scripts/planning_executor.sh`
  - `scripts/qa_triage_executor.sh`
  - `scripts/ralph_loop_local.sh`

## Why
Recent Agent Loop run for planner issue #17 failed with:
`error: unexpected argument '--ask-for-approval' found`

## Validation
- `bash -n scripts/agent_executor.sh scripts/planning_executor.sh scripts/qa_triage_executor.sh scripts/ralph_loop_local.sh`
- `codex --ask-for-approval never exec --help`
