### PR TITLE
fix(agent-loop): prevent checkout output from polluting branch name

### DIFF
--- a/scripts/agent_loop.sh
+++ b/scripts/agent_loop.sh
@@ -193,7 +193,7 @@ create_branch_for_issue() {
   fi
 
   git fetch origin "${BASE_BRANCH}"
-  git checkout -B "${branch}" "origin/${BASE_BRANCH}"
+  git checkout -B "${branch}" "origin/${BASE_BRANCH}" >/dev/null
   echo "${branch}"
 }
 


### PR DESCRIPTION
## Summary
- fix branch-name capture in `scripts/agent_loop.sh` by silencing `git checkout` stdout
- prevents `invalid refspec` when the function output is captured via command substitution

## Why
Planner run for issue #17 failed at push with refspec pollution from checkout output.

## Validation
- `bash -n scripts/agent_loop.sh`
