### PR TITLE
fix(agent-auto-merge): correct ready-for-review API call

### DIFF
--- a/.github/workflows/agent-auto-merge.yml
+++ b/.github/workflows/agent-auto-merge.yml
@@ -99,7 +99,7 @@ jobs:
 
             if (pr.draft) {
               try {
-                await github.rest.pulls.readyForReview({
+                await github.request("POST /repos/{owner}/{repo}/pulls/{pull_number}/ready_for_review", {
                   owner,
                   repo,
                   pull_number: prNumber,


### PR DESCRIPTION
## Summary
- fix Agent Auto Merge draft conversion path
- use direct REST endpoint `POST /repos/{owner}/{repo}/pulls/{pull_number}/ready_for_review`

## Why
`github.rest.pulls.readyForReview` is not available in current github-script runtime, so draft PRs were never converted.
