### PR TITLE
fix(agent-auto-merge): mark draft ready via GraphQL

### DIFF
--- a/.github/workflows/agent-auto-merge.yml
+++ b/.github/workflows/agent-auto-merge.yml
@@ -99,11 +99,14 @@ jobs:
 
             if (pr.draft) {
               try {
-                await github.request("POST /repos/{owner}/{repo}/pulls/{pull_number}/ready_for_review", {
-                  owner,
-                  repo,
-                  pull_number: prNumber,
-                });
+                await github.graphql(
+                  `mutation MarkReady($pullRequestId: ID!) {
+                    markPullRequestReadyForReview(input: {pullRequestId: $pullRequestId}) {
+                      pullRequest { number isDraft }
+                    }
+                  }`,
+                  { pullRequestId: pr.node_id }
+                );
                 core.notice(`PR #${prNumber} converted to ready-for-review.`);
               } catch (err) {
                 core.warning(`Unable to convert PR #${prNumber} from draft: ${err.message}`);


### PR DESCRIPTION
## Summary
- fix draft -> ready conversion in Agent Auto Merge workflow
- use GraphQL mutation `markPullRequestReadyForReview` with PR node id

## Why
REST path returned Not Found in workflow runtime for draft conversion.
