### PR TITLE
fix(agent-auto-merge): recover workflow parse + token fallback

### DIFF
--- a/.github/workflows/agent-auto-merge.yml
+++ b/.github/workflows/agent-auto-merge.yml
@@ -22,7 +22,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: read
-  workflows: write
 
 concurrency:
   group: agent-auto-merge-${{ github.event.pull_request.number || github.event.inputs.pr_number || 'manual' }}
@@ -38,6 +37,7 @@ jobs:
         env:
           AGENT_AUTO_MERGE_ENABLED: ${{ vars.AGENT_AUTO_MERGE_ENABLED || 'true' }}
         with:
+          github-token: ${{ secrets.AGENT_GH_TOKEN || github.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -48,7 +48,8 @@ jobs:
               "decision/major",
               "risk/high",
             ]);
-            const inputPr = `${{ toJSON(github.event.inputs.pr_number) }}`.replace(/^"+|"+$/g, "");
+            const rawInputPr = `${{ toJSON(github.event.inputs.pr_number) }}`.replace(/^"+|"+$/g, "");
+            const inputPr = rawInputPr === "null" ? "" : rawInputPr.trim();
             const eventPr = context.payload.pull_request?.number;
             const requestedPrNumber = inputPr ? Number(inputPr) : eventPr;
             const isAgentPr = (pr) =>
@@ -153,6 +154,11 @@ jobs:
                 ) {
                   core.notice(`Auto-merge already configured for PR #${prNumber}.`);
                   return;
+                }
+                if (message.includes("without `workflows` permission") || message.includes("without workflows permission")) {
+                  core.warning(
+                    "Workflow-file PR auto-merge needs secret AGENT_GH_TOKEN (classic PAT with repo+workflow scopes)."
+                  );
                 }
                 core.warning(`enablePullRequestAutoMerge failed for #${prNumber}: ${message}`);
               }

--- a/README.md
+++ b/README.md
@@ -457,8 +457,10 @@ GitHub 이슈를 큐로 사용해 밤새 자동 작업하려면 아래 순서로
    - 해당 이슈는 owner 입력 전 자동 실행이 진행되지 않음
 12. PR 자동 머지:
    - `Agent Auto Merge` 워크플로가 agent PR을 조건부 자동 머지
+   - 15분 주기 스캔으로 미처리 agent PR을 재수집
    - 차단 라벨(`decision-needed`, `needs-opinion`, `blocked`, `decision/major`, `risk/high`)이 있으면 머지 중단
    - 토글 변수: `AGENT_AUTO_MERGE_ENABLED=true|false`
+   - 선택: `AGENT_GH_TOKEN` secret(repo+workflow scope) 설정 시 workflow 파일 변경 PR까지 자동 머지 가능
 13. 로컬 반복 루프(Playbook 스타일):
    - 작업 지시를 `.agent/ralph_task.md`에 작성
    - `MAX_LOOPS=6 scripts/ralph_loop_local.sh`

--- a/docs/autonomy-policy.md
+++ b/docs/autonomy-policy.md
@@ -152,8 +152,10 @@
 - 주기: 15분
 - 수동 실행: `workflow_dispatch`
 - PR 자동 머지 워크플로우: `.github/workflows/agent-auto-merge.yml`
+  - 트리거: PR 이벤트 + 15분 주기 스캔 + 수동 실행
   - 대상: agent가 생성한 PR(`agent-issue-*`, `chore(agent):*`)
   - 조건: 차단 라벨(`decision-needed`, `needs-opinion`, `blocked`, `decision/major`, `risk/high`) 없음
+  - 선택: secret `AGENT_GH_TOKEN`(`repo` + `workflow` scope) 설정 시 workflow 파일 변경 PR까지 자동 머지 가능
 
 ## Operational Notes
 - 기본 실행자는 `ubuntu-latest`이다.

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -34,6 +34,7 @@
 
 ## Autonomous Merge
 - 워크플로우: `.github/workflows/agent-auto-merge.yml`
+- 트리거: `pull_request_target` + 15분 주기 스캔 + 수동 `workflow_dispatch`
 - 대상 PR:
   - head branch가 `agent-issue-*`
   - 또는 제목이 `chore(agent):`로 시작
@@ -41,7 +42,10 @@
   - 연동 이슈에 `blocked`, `decision-needed`, `needs-opinion`, `decision/major`, `risk/high` 라벨이 있으면 merge 중단
 - merge 방식:
   - 우선 auto-merge(squash) 활성화
+  - `mergeable_state=behind`면 base 최신으로 branch update 시도 후 auto-merge 재시도
   - 불가 시 체크가 이미 green이면 즉시 squash merge 시도
+- 선택 설정:
+  - secret `AGENT_GH_TOKEN`(classic PAT, `repo` + `workflow` scope)을 설정하면 workflow 파일을 수정한 PR도 자동 merge 가능
 
 ## Issue Discovery Loop
 - 워크플로우: `.github/workflows/issue-scout.yml`


### PR DESCRIPTION
## Summary
- remove invalid permissions key that broke Agent Auto Merge workflow parsing
- fix null input parsing for pull_request_target events
- keep scheduled open-agent-PR scan and behind-branch update behavior
- allow optional secret token via AGENT_GH_TOKEN for workflow-file PR auto-merge

## Validation
- Agent Auto Merge workflow is parseable again after this change
