### PR TITLE
fix(ralph): hotfix self-heal workflow runtime

### DIFF
--- a/.github/workflows/agent-auto-merge.yml
+++ b/.github/workflows/agent-auto-merge.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/github-script@v7
         env:
           AGENT_AUTO_MERGE_ENABLED: ${{ vars.AGENT_AUTO_MERGE_ENABLED || 'true' }}
-          HAS_AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN != '' && 'true' || 'false' }}
         with:
           github-token: ${{ secrets.AGENT_GH_TOKEN || github.token }}
           script: |
@@ -70,10 +69,6 @@ jobs:
                 return;
               }
 
-              const hasToken = process.env.HAS_AGENT_GH_TOKEN === "true";
-              const tokenStatus = hasToken
-                ? "AGENT_GH_TOKEN is configured, but likely missing `workflow` scope."
-                : "AGENT_GH_TOKEN is not configured.";
               await github.rest.issues.createComment({
                 owner,
                 repo,
@@ -82,7 +77,7 @@ jobs:
 Auto-merge is blocked by workflow-file permission policy.
 
 - reason: ${message}
-- status: ${tokenStatus}
+- status: confirm AGENT_GH_TOKEN is configured with scopes \`repo\`, \`workflow\`
 
 Fix:
 1. Create a classic PAT with scopes: \`repo\`, \`workflow\`

--- a/scripts/agent_loop.sh
+++ b/scripts/agent_loop.sh
@@ -129,10 +129,10 @@ pick_next_issue() {
         elif labels | index("priority/p1") then 1
         elif labels | index("priority/p2") then 2
         elif labels | index("priority/p3") then 3
-        else 9 end;
-      ($include | csv) as $required_labels
-      | ($exclude | csv) as $excluded_labels
-      map(select(
+      else 9 end;
+      (csv($include)) as $required_labels
+      | (csv($exclude)) as $excluded_labels
+      | map(select(
         (labels | index("blocked") | not) and
         (labels | index("decision-needed") | not) and
         (labels | index("decision/major") | not) and


### PR DESCRIPTION
## Summary
- fix jq filter in scripts/agent_loop.sh pick_next_issue (compile/runtime failure)
- simplify Agent Auto Merge script env to avoid workflow parsing instability

## Validation
- AUTONOMY_DRY_RUN=true scripts/agent_loop.sh (passes)
- bash -n scripts/agent_loop.sh
