### PR TITLE
fix(agent-loop): restore developer queue selection

### DIFF
--- a/scripts/agent_loop.sh
+++ b/scripts/agent_loop.sh
@@ -145,11 +145,11 @@ pick_next_issue() {
               ($labels | index("agent/needs-config") | not) and
               (
                 ($required_labels | length) == 0 or
-                all($required_labels[]; $labels | index(.) != null)
+                all($required_labels[]; . as $req | $labels | index($req) != null)
               ) and
               (
                 ($excluded_labels | length) == 0 or
-                all($excluded_labels[]; $labels | index(.) == null)
+                all($excluded_labels[]; . as $excluded | $labels | index($excluded) == null)
               )
             )
         )


### PR DESCRIPTION
## Summary
- fix jq all() predicate to compare against each excluded label value correctly
- previously, developer queue treated all candidates as excluded and selected none

## Validation
- dry-run picks issue #27 with exclude labels enabled
