### PR TITLE
fix: start agent loop immediately on ralph ON

### DIFF
--- a/.github/workflows/ralph-loop-control.yml
+++ b/.github/workflows/ralph-loop-control.yml
@@ -22,7 +22,7 @@ on:
         options:
           - "no"
           - "yes"
-        default: "no"
+        default: "yes"
       kick_max_issues:
         description: "Max issues for one-time Agent Loop kick"
         required: false
@@ -40,7 +40,8 @@ jobs:
 
       - name: Control Ralph Loop
         env:
-          GH_TOKEN: ${{ secrets.RALPH_ADMIN_TOKEN }}
+          GH_TOKEN: ${{ secrets.RALPH_ADMIN_TOKEN != '' && secrets.RALPH_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MODE: ${{ github.event.inputs.mode }}
           NOTE: ${{ github.event.inputs.note }}
           REPO: ${{ github.repository }}
@@ -57,7 +58,8 @@ jobs:
       - name: Kick Agent Loop (optional)
         if: ${{ github.event.inputs.kick_agent_loop == 'yes' && github.event.inputs.mode != 'off' }}
         env:
-          GH_TOKEN: ${{ secrets.RALPH_ADMIN_TOKEN }}
+          GH_TOKEN: ${{ secrets.RALPH_ADMIN_TOKEN != '' && secrets.RALPH_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           MAX_ISSUES: ${{ github.event.inputs.kick_max_issues }}
         run: |


### PR DESCRIPTION
## Summary
- change `ralph-loop-control` default `kick_agent_loop` from `no` to `yes`
- use token fallback for control/kick steps:
  - `RALPH_ADMIN_TOKEN` if present
  - else `GITHUB_TOKEN`

## Why
Operators toggling `mode=on` expected immediate work start, but default behavior required waiting for schedule. This makes ON action trigger a one-time Agent Loop kick by default.

## Validation
- workflow syntax checked in repo context
- existing manual test already showed agent loop can be dispatched and run (`run_id=22000089902`)
